### PR TITLE
[OGUI-1369] Update release.yml to remove archived and deprecated usage of GH actions and commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install production dependencies
       run: npm install --only=production
     - name: Create package tarball
-      run:  echo ::set-output name=tgz_name::$(npm pack)
+      run: echo "tgz_name=$(npm pack)" >> $GITHUB_OUTPUT
       id: tgz
     - name: Upload tarball to release assets via GH CLI
       working-directory: ./RunConditionTable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   deploy-npm-module:
     runs-on: ubuntu-latest
+    outputs:
+      VERSION: ${{ steps.set-project.outputs.version }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
@@ -26,6 +28,7 @@ jobs:
         PROJECT="RunConditionTable"
         echo "Identified project: $PROJECT with version: $VERSION"
         echo "PROJECT=$PROJECT" >> $GITHUB_ENV
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
     - run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_DEPLOY_TOKEN }}
@@ -45,16 +48,11 @@ jobs:
     - name: Create package tarball
       run:  echo ::set-output name=tgz_name::$(npm pack)
       id: tgz
-    - name: Upload tarball to GH release assets
-      uses: actions/upload-release-asset@v1
-      id: upload
+    - name: Upload tarball to release assets via GH CLI
+      working-directory: ./RunConditionTable
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_content_type: application/tar+gzip
-        asset_path: ./${{ steps.tgz.outputs.tgz_name }}
-        asset_name: ${{ steps.tgz.outputs.tgz_name }}
+      run: gh release upload @aliceo2/run-condition-table@${{ needs.deploy-npm-module.outputs.VERSION }} ${{ steps.tgz.outputs.tgz_name }}
     - name: Upload TARball to S3
       uses: awegrzyn/s3-put-action@v1
       with:


### PR DESCRIPTION
PR which: 
* removes the usage of `set-output` as it is already deprecated and to be removed from GH Action
* removes the usage of 3rd party action `actions/upload-release-asset@v1` as it has been archived and instead use GH cli to replace functionality