### PR TITLE
🐛 Table name misspelling

### DIFF
--- a/app/lib/database/procedures/flags.js
+++ b/app/lib/database/procedures/flags.js
@@ -21,7 +21,7 @@ const flag_insert = (query) => `
     BEGIN
         select id into pass_id from data_passes where name = '${query.data_pass_name}';
         select id into det_id from detectors_subsystems where name = '${query.detector}';
-        select id into flag_id from flags_types_dictionary where name = '${query.flag_type}';
+        select id into flag_id from flag_types_dictionary where name = '${query.flag_type}';
 
         INSERT INTO quality_control_flags (data_pass_id, run_number, detector_id, flag_type_id, 
             time_start, time_end, comment, added_by, addition_time, last_modified_by, last_modification_time)

--- a/app/lib/database/views/flags_view.js
+++ b/app/lib/database/views/flags_view.js
@@ -49,7 +49,7 @@ const flags_view = (query) => {
             ON qcf.run_number = r.run_number
         INNER JOIN detectors_subsystems AS ds
             ON ds.id = qcf.detector_id
-        INNER JOIN flags_types_dictionary as ftd
+        INNER JOIN flag_types_dictionary as ftd
             ON ftd.id = qcf.flag_type_id
         LEFT OUTER JOIN verifications as v
             ON qcf.id = v.qcf_id

--- a/database/design.dbm
+++ b/database/design.dbm
@@ -3,7 +3,7 @@
 CAUTION: Do not modify this file unless you know what you are doing.
  Unexpected results may occur if the code is changed deliberately.
 -->
-<dbmodel pgmodeler-ver="1.0.4" use-changelog="false" last-position="0,306" last-zoom="1" max-obj-count="31"
+<dbmodel pgmodeler-ver="1.0.4" use-changelog="false" last-position="0,292" last-zoom="1" max-obj-count="31"
 	 default-owner="postgres"
 	 layers="Default layer"
 	 active-layers="0"
@@ -176,11 +176,6 @@ CAUTION: Do not modify this file unless you know what you are doing.
 		<columns names="name" ref-type="src-columns"/>
 	</constraint>
 </table>
-
-<sequence name="flags_types_dictionary_id_seq" cycle="false" start="1" increment="1" min-value="1" max-value="2147483647" cache="1">
-	<schema name="public"/>
-	<role name="postgres"/>
-</sequence>
 
 <table name="flag_types_dictionary" layers="0" collapse-mode="2" max-obj-count="6" z-value="0">
 	<schema name="public"/>

--- a/database/exported/create-tables.sql
+++ b/database/exported/create-tables.sql
@@ -141,21 +141,6 @@ CREATE TABLE public.detectors_subsystems (
 ALTER TABLE public.detectors_subsystems OWNER TO postgres;
 -- ddl-end --
 
--- object: public.flags_types_dictionary_id_seq | type: SEQUENCE --
--- DROP SEQUENCE IF EXISTS public.flags_types_dictionary_id_seq CASCADE;
-CREATE SEQUENCE public.flags_types_dictionary_id_seq
-	INCREMENT BY 1
-	MINVALUE 1
-	MAXVALUE 2147483647
-	START WITH 1
-	CACHE 1
-	NO CYCLE
-	OWNED BY NONE;
-
--- ddl-end --
-ALTER SEQUENCE public.flags_types_dictionary_id_seq OWNER TO postgres;
--- ddl-end --
-
 -- object: public.flag_types_dictionary | type: TABLE --
 -- DROP TABLE IF EXISTS public.flag_types_dictionary CASCADE;
 CREATE TABLE public.flag_types_dictionary (

--- a/docs/flags/mock.md
+++ b/docs/flags/mock.md
@@ -59,7 +59,7 @@ VALUES
         ON qcf.run_number = r.run_number
     INNER JOIN detectors_subsystems AS ds
         ON ds.id = qcf.detector_id
-    INNER JOIN flags_types_dictionary as ftd
+    INNER JOIN flag_types_dictionary as ftd
         ON ftd.id = qcf.flag_type_id
     LEFT OUTER JOIN verifications as v
         ON qcf.id = v.qcf_id


### PR DESCRIPTION
No jira issue.
- [x] PR labels are selected

Notable changes for developers:
- Missing table renaming
- Cleanup of pgModeler design
