### PR TITLE
ORCT-45 - between clause handle incorrect syntax, tests

### DIFF
--- a/app/lib/database/QueryBuilder.js
+++ b/app/lib/database/QueryBuilder.js
@@ -112,7 +112,6 @@ class QueryBuilder {
     }
 
     static buildSelect(params) {
-        console.log(params);
         const dataSubsetQueryPart = (params) => params[DRP.countRecords] === 'true' ? '' :
             `LIMIT ${params[DRP.rowsOnSite]} OFFSET ${params[DRP.rowsOnSite] * (params[DRP.site] - 1)}`;
 
@@ -133,14 +132,13 @@ class QueryBuilder {
         const viewName = pageToViewName[params.page]
         const viewGen = views[viewName]
 
-        const a = `WITH ${viewName} AS (
+        return `WITH ${viewName} AS (
                     ${viewGen(params)})
                 SELECT *
                 FROM ${viewName}
                 ${QueryBuilder.filteringPart(params)}
                 ${orderingPart(params)}
                 ${dataSubsetQueryPart(params)};`;
-        return a;
     }
 
     static buildInsertOrUpdate(params) {

--- a/app/lib/database/QueryBuilder.js
+++ b/app/lib/database/QueryBuilder.js
@@ -38,13 +38,16 @@ const handleBetween = (fieldName, pairsList) => {
         pairsList = [pairsList]
     }
     return pairsList.map((p) => {
-        const value = p.split(',');
-        const [left, right] = adjustValuesToSql(value);
-        if (value[0] && value[1]) {
+        const range = p.split(',');
+        if (range.length !== 2) {
+            throw 'between clause is incorrectly formatted';
+        }
+        const [left, right] = adjustValuesToSql(range);
+        if (range[0] && range[1]) {
             return `${fieldName} BETWEEN ${left} AND ${right}`;
-        } else if (value[0]) {
+        } else if (range[0]) {
             return `${fieldName} >= ${left}`;
-        } else if (value[1]) {
+        } else if (range[1]) {
             return `${fieldName} <= ${right}`;
         }
     }).join(' OR ');
@@ -109,6 +112,7 @@ class QueryBuilder {
     }
 
     static buildSelect(params) {
+        console.log(params);
         const dataSubsetQueryPart = (params) => params[DRP.countRecords] === 'true' ? '' :
             `LIMIT ${params[DRP.rowsOnSite]} OFFSET ${params[DRP.rowsOnSite] * (params[DRP.site] - 1)}`;
 

--- a/app/lib/database/index.js
+++ b/app/lib/database/index.js
@@ -13,7 +13,9 @@
  */
 
 const databaseService = require('./DatabaseService');
-
+const QueryBuilder = require('./QueryBuilder')
 module.exports = {
-    databaseService
-}
+    databaseService,
+    QueryBuilder,
+};
+


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [x] issue has "Fix version" assigned
- [x] PR labels are selected

Notable changes for users:
- if 'between' clause is incorrectly formatted, backend responds with error

Notable changes for developers:
- more tests (QueryBuilder)

