### PR TITLE
[ORCT-177] Add dependabot auto-checker for dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "monthly"
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: "tuesday"
+    time: "07:00"
+    timezone: "Europe/Zurich"
+  groups:
+    dev-dependencies:
+      patterns:
+        - "chai"
+        - "eslint"
+        - "js-yaml"
+        - "mocha"
+        - "nodemon"
+        - "nyc"
+        - "puppeteer"
+        - "puppeteer-to-istanbul"
+        - "sequelize-cli"
+        - "sinon"
+        - "supertest"
+        - "eslint-output"
+        - "run-script-os"
+        - "socks-proxy-agent"
+  open-pull-requests-limit: 10
+  versioning-strategy: increase
+  ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-patch"]
+  reviewers:
+      - "Ehevi"
+      - "xsalonx"


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [NA] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for developers:
* Adds dependabot configuration which is a tool automatically checking for:
    * new versions for used github-actions
    * new versions (minor and major) for NPM dependencies within the project
