### PR TITLE
[ORCT-182] add workaround for sequelize misbehaviour

### DIFF
--- a/test/lib/server/filters.test.js
+++ b/test/lib/server/filters.test.js
@@ -194,6 +194,29 @@ module.exports = () => {
 
                 assert.deepStrictEqual(expectedFilter, filterToSequelizeWhereClause(srcFilter));
             });
+
+            /**
+             * @see filterToSequelizeWhereClause#workaroundForSequlizeBug
+             */
+            it('test workaround for sequelize misbehaviour', () => {
+                const srcFilter = {
+                    name: {
+                        and: { f1: 1 },
+                        or: { f2: 2 },
+                    },
+                };
+
+                const expectedFilter = {
+                    name: {
+                        [Op.and]: {
+                            [Op.and]: { f1: 1 },
+                            [Op.or]: { f2: 2 },
+                        },
+                    },
+                };
+
+                assert.deepStrictEqual(expectedFilter, filterToSequelizeWhereClause(srcFilter));
+            });
         });
     });
 };


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [ ] issue has "Fix version" assigned
- [x] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- NA

Notable changes for developers:
- see `app/lib/server/utilities/filterParser.js` changes, method `workaroundForSequlizeBug`

Changes made to the database:
- NA
