### PR TITLE
[ORCT-162] provide number of existing related data for simulation passes views

### DIFF
--- a/app/lib/database/adapters/SimulationPassAdapter.js
+++ b/app/lib/database/adapters/SimulationPassAdapter.js
@@ -28,7 +28,9 @@ class SimulationPassAdapter {
             PWG,
             requestedEvents,
             outputSize,
-        } = databaseObject;
+            dataPassesCount,
+            runsCount,
+        } = databaseObject.dataValues;
 
         return {
             id,
@@ -38,6 +40,8 @@ class SimulationPassAdapter {
             PWG,
             requestedEvents,
             outputSize,
+            dataPassesCount: Number(dataPassesCount),
+            runsCount: Number(runsCount),
         };
     }
 

--- a/app/lib/services/simulationPasses/SimulationPassService.js
+++ b/app/lib/services/simulationPasses/SimulationPassService.js
@@ -104,7 +104,10 @@ class SimulationPassService {
             });
 
         const { count, rows } = await SimulationPassRepository.findAndCountAll(new QueryBuilder(baseClause).addFromHttpRequestQuery(query));
-        return { count, rows: rows.map((simulationPass) => simulationPassAdapter.toEntity(simulationPass)) };
+        return {
+            count: count.length,
+            rows: rows.map((simulationPass) => simulationPassAdapter.toEntity(simulationPass)),
+        };
     }
 
     /**

--- a/app/lib/services/simulationPasses/SimulationPassService.js
+++ b/app/lib/services/simulationPasses/SimulationPassService.js
@@ -115,22 +115,36 @@ class SimulationPassService {
      */
     async getAnchorageForDataPass(dataPassId, query) {
         const baseClause = {
-            include: [
-                {
-                    model: DataPass,
-                    required: true,
-                    attributes: [],
-                    through: {
-                        where: {
-                            data_pass_id: dataPassId,
+            ...commonClause,
+            ...{
+                include: [
+                    {
+                        model: Run,
+                        required: false,
+                        attributes: [],
+                        through: {
+                            attributes: [],
                         },
                     },
-                },
-            ],
+                    {
+                        model: DataPass,
+                        required: true,
+                        attributes: [],
+                        where: {
+                            id: dataPassId,
+                        },
+                        through: {
+                            attributes: [],
+                        },
+                    },
+                ] },
         };
 
         const { count, rows } = await SimulationPassRepository.findAndCountAll(new QueryBuilder(baseClause).addFromHttpRequestQuery(query));
-        return { count, rows: rows.map((simulationPass) => simulationPassAdapter.toEntity(simulationPass)) };
+        return {
+            count: count.length,
+            rows: rows.map((simulationPass) => simulationPassAdapter.toEntity(simulationPass)),
+        };
     }
 }
 


### PR DESCRIPTION
#### I have a JIRA ticket
- [x] branch and/or PR name(s) include(s) JIRA ID
- [ ] issue has "Fix version" assigned
- [ ] issue "Status" is set to "In review"
- [x] PR labels are selected

Notable changes for users:
- NA

Notable changes for developers:
- add counts of related data for simulation passes views: `runsCount` and `dataPassesCount`

Changes made to the database:
- NA
